### PR TITLE
Fix double "Cannot shoot:" text

### DIFF
--- a/1.4/Defs/ThingDefs_Buildings/Buildings_AdvancedStructure.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_AdvancedStructure.xml
@@ -241,7 +241,7 @@
         <fuelMultiplier>10</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Out of ammo</outOfFuelMessage>
+        <outOfFuelMessage>Out of ammo</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/FuelAmmo</fuelIconPath>
       </li>
     </comps>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_AdvancedTurrets.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_AdvancedTurrets.xml
@@ -63,7 +63,7 @@
         <fuelMultiplier>0.5</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new barrel</outOfFuelMessage>
+        <outOfFuelMessage>Needs new barrel</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/Barrel</fuelIconPath>
       </li>
     </comps>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_ChargeComplex.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_ChargeComplex.xml
@@ -66,7 +66,7 @@
         <fuelMultiplier>100</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new battery</outOfFuelMessage>
+        <outOfFuelMessage>Needs new battery</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/Barrel</fuelIconPath>
       </li>
     </comps>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_IndustrialTurrets.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_IndustrialTurrets.xml
@@ -67,7 +67,7 @@
         <fuelMultiplier>2</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new barrels</outOfFuelMessage>
+        <outOfFuelMessage>Needs new barrels</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/Barrel</fuelIconPath>
       </li>
     </comps>
@@ -312,7 +312,7 @@
         <fuelMultiplier>1</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs chemfuel</outOfFuelMessage>
+        <outOfFuelMessage>Needs chemfuel</outOfFuelMessage>
         <fuelIconPath>Things/Item/Resource/Chemfuel</fuelIconPath>
       </li>
     </comps>
@@ -473,7 +473,7 @@
         <fuelMultiplier>0.5</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new barrel</outOfFuelMessage>
+        <outOfFuelMessage>Needs new barrel</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/Barrel</fuelIconPath>
       </li>
     </comps>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_MedievalTurrets.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_MedievalTurrets.xml
@@ -60,7 +60,7 @@
         <fuelMultiplier>0.2</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs ballista bolts</outOfFuelMessage>
+        <outOfFuelMessage>Needs ballista bolts</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/FuelBallistaBolt</fuelIconPath>
         <initialFuelPercent>1</initialFuelPercent>
       </li>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_SpacerTurrets.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_SpacerTurrets.xml
@@ -68,7 +68,7 @@
         <fuelMultiplier>6</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new barrel</outOfFuelMessage>
+        <outOfFuelMessage>Needs new barrel</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/Barrel</fuelIconPath>
       </li>
     </comps>
@@ -208,7 +208,7 @@
         <fuelMultiplier>30</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Needs new components</outOfFuelMessage>
+        <outOfFuelMessage>Needs new components</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/FuelComponent</fuelIconPath>
       </li>
     </comps>
@@ -366,7 +366,7 @@
         <fuelMultiplier>0.5</fuelMultiplier>
         <factorByDifficulty>true</factorByDifficulty>
         <consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
-        <outOfFuelMessage>Cannot shoot: Need uranium</outOfFuelMessage>
+        <outOfFuelMessage>Need uranium</outOfFuelMessage>
         <fuelIconPath>UI/Overlays/FuelUranium</fuelIconPath>
       </li>
     </comps>


### PR DESCRIPTION
Vanilla adds "Cannot shoot:" at the beginning of out of ammo message for all turrets, so the text of those turrets was not needed and ended up with (for example) "Cannot shoot: Cannot shoot: Needs new barrel".